### PR TITLE
[RWLT-76][master]

### DIFF
--- a/src/components/CardProduct/index.js
+++ b/src/components/CardProduct/index.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import Image from '../Image'
 import ProductDescription from '../ProductDescription'
+import { Link } from 'react-router-dom'
 
 import './style.scss';
 
-const CardProduct = ({ src, alt, discountPrice, className, name, regularPrice, actualPrice, onSale }) => {
+const CardProduct = ({ src, alt, discountPrice, className, name, regularPrice, actualPrice, onSale, productId }) => {
 
   return (
-    <div className='cardProductDefault__inner' tabIndex="0">
+    <Link to={`/product/${productId}`} className='cardProductDefault__inner' tabIndex="0">
       <Image
         src={src}
         alt={alt}
@@ -20,7 +21,7 @@ const CardProduct = ({ src, alt, discountPrice, className, name, regularPrice, a
         actualPrice={actualPrice}
         onSale={onSale}
       />
-    </div>
+    </Link>
   );
 };
 

--- a/src/components/CardProduct/index.js
+++ b/src/components/CardProduct/index.js
@@ -7,7 +7,7 @@ import './style.scss';
 const CardProduct = ({ src, alt, discountPrice, className, name, regularPrice, actualPrice, onSale }) => {
 
   return (
-    <div className='cardProductDefault__inner'>
+    <div className='cardProductDefault__inner' tabIndex="0">
       <Image
         src={src}
         alt={alt}

--- a/src/components/CardProduct/style.scss
+++ b/src/components/CardProduct/style.scss
@@ -1,19 +1,21 @@
 @import 'src/base-styles/dependencies';
 
 .cardProductDefault {
-  
-   @include mq-min(md) {
-      margin: 15px 0px 30px 42px;
-    }
 
-   @include mq-min(xl) {
-      width: 22.64%;
-      margin: 15px 0px 30px 22px;
-      max-height: 412px;
+  @include mq-min(md) {
+    margin: 15px 0px 30px 42px;
+  }
+
+  @include mq-min(xl) {
+    width: 22.64%;
+    margin: 15px 0px 30px 22px;
+    max-height: 412px;
 
   }
 
   &__inner {
+    text-decoration: none;
+    color: inherit;
     width: 40%;
     margin-bottom: 32px;
     // position: relative;

--- a/src/components/ProductInfo/index.js
+++ b/src/components/ProductInfo/index.js
@@ -17,7 +17,7 @@ const product = {
   installments: '3x R$ 66,63',
 };
 
-const ProductInfo = ({ addProduct }) => {
+const ProductInfo = ({ addProduct, layout, name, regularPrice, actualPrice, installments, onSale }) => {
   const [selectedSize, setSelectecSize] = useState('');
 
   const handleSizeSelection = (event) => {
@@ -26,7 +26,14 @@ const ProductInfo = ({ addProduct }) => {
 
   return (
     <div className='productInfo'>
-      <ProductDescription {...product} />
+      <ProductDescription
+        layout={layout}
+        name={name}
+        regularPrice={regularPrice}
+        actualPrice={actualPrice}
+        installments={installments}
+        onSale={onSale}
+      />
       <SizeSelect selectedSize={selectedSize} handleSizeSelection={handleSizeSelection} />
       <ButtonCta
         text='Adicionar à sacola de compras'

--- a/src/components/SelectUnit/index.js
+++ b/src/components/SelectUnit/index.js
@@ -5,7 +5,7 @@ import './style.scss';
 const SelectUnit = ({ amount, handleMinusClick, handlePlusClick }) => {
   return (
     <div className='containerUnit'>
-      <button className='buttonUnit buttonUnit__fontSize--minus' onClick={handleMinusClick}>
+      <button className='buttonUnit buttonUnit__fontSize--minus' onClick={handleMinusClick} aria-label="remover unidade">
         -
       </button>
       {amount === 5 ? (
@@ -14,9 +14,9 @@ const SelectUnit = ({ amount, handleMinusClick, handlePlusClick }) => {
           <p className='unitMessage'>Ops! Quantidade indisponível :(</p>
         </div>
       ) : (
-        <span className='unitNumber'> {amount} </span>
-      )}
-      <button className='buttonUnit buttonUnit__fontSize--plus' onClick={handlePlusClick}>
+          <span className='unitNumber'> {amount} </span>
+        )}
+      <button className='buttonUnit buttonUnit__fontSize--plus' onClick={handlePlusClick} aria-label="adicionar unidade">
         +
       </button>
     </div>

--- a/src/pages/Home/index.js
+++ b/src/pages/Home/index.js
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom'
 
 import CardProduct from '../../components/CardProduct/index'
 import { getCatalog } from '../../services/catalog';
@@ -18,23 +17,22 @@ const Home = () => {
     <div className='pageContent'>
       {
         catalog && catalog.map(item => {
-          return(
-            // <Link to={`/product/${item.code_color}`}>
-              <CardProduct
-                key={item.code_color}
-                src={item.image}
-                alt={`${item.name}`}
-                discountPrice={item.discount_percentage !== '' ? `${item.discount_percentage} OFF` : ''}
-                className={item.on_sale ? 'discount' : 'discount--none'}
-                name={item.name}
-                onSale={item.on_sale}
-                actualPrice={item.actual_price}
-                regularPrice={item.regular_price}
-              />
-            // </Link>
+          return (
+            <CardProduct
+              key={item.code_color}
+              src={item.image}
+              alt={`${item.name}`}
+              discountPrice={item.discount_percentage !== '' ? `${item.discount_percentage} OFF` : ''}
+              className={item.on_sale ? 'discount' : 'discount--none'}
+              name={item.name}
+              onSale={item.on_sale}
+              actualPrice={item.actual_price}
+              regularPrice={item.regular_price}
+              productId={item.code_color}
+            />
           )
         })
-        
+
       }
     </div>
   );

--- a/src/pages/Product/index.js
+++ b/src/pages/Product/index.js
@@ -1,13 +1,35 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router';
 import '../defaultStyles.scss';
+import { getCatalog } from '../../services/catalog';
+import Image from '../../components/Image';
+import ProductInfo from '../../components/ProductInfo'
 
 const Product = () => {
   const { productCode } = useParams();
+  const [catalog, setCatalog] = useState([]);
+
+  useEffect(() => {
+    getCatalog().then(resp => setCatalog(resp.data));
+  }, []);
+  const produto = catalog.find(produto => produto.code_color === productCode)
 
   return (
     <div className='pageContent'>
-      <h1>Página do produto {productCode}</h1>
+      {produto &&
+        <>
+          <Image
+            src={produto.image}
+            alt={produto.name}
+          />
+          <ProductInfo
+            name={produto.name}
+            regularPrice={produto.regular_price}
+            actualPrice={produto.actual_price}
+            installments={` em até ${produto.installments}`}
+            onSale={produto.on_sale}
+          />
+        </>}
     </div>
   );
 };


### PR DESCRIPTION
# Página de detalhe do produto

### Remove Link do produto de Home e associa a CardProduct, importa props de ProductDescription, implementa primeira versão da página do produto

## Capturas de Tela
![card-product](https://user-images.githubusercontent.com/42470334/85933069-10428480-b8a9-11ea-9d44-07ffcc70c304.gif)

## Issue do repo

#34 

## Casos de Teste Pensados
__x__

## Descrição técnica da solução

Associa Link do produto ao componente Card Product, importa props de Product Info e Product Description para composição da página de detalhe do Produto populada a partir da validação entre productCode de `useParams` e key `code_color` da API.

## Dilemas, dúvidas e dívidas

Identificamos os seguintes pontos de atenção relacionados à página do Produto:

- Necessário ajustes na estrutura do Redux para receber o produto 'Adicionado à sacola' a partir da página de detalhe do Produto para o modal do Carrinho;
- Será necessário também ajustes do select de tamanhos para contemplar sizes numéricos da API;
- Será necessário validar as classes do layout página do Produto para mobile
