### PR TITLE
[RWLT-81-quebra-layout][master]

### DIFF
--- a/src/components/Cart/ProductBox/style.scss
+++ b/src/components/Cart/ProductBox/style.scss
@@ -3,7 +3,7 @@
 .productBox {
   display: flex;
   justify-content: space-between;
-  height: 178px;
+  min-height: 178px;
   border-bottom: 0.125em solid $border-primary;
   padding: 0.912em 0;
 


### PR DESCRIPTION

# Correção de quebra de layout no modal do carrinho quando há o preço atual e preço antigo

## Descrição do PR

Havia uma altura fixa na div de cada produto que estava causando a quebra, quando os elementos internos possuíam tamanho maior do que o setado. 

## Capturas de Tela
MOBILE
![Fashionista](https://user-images.githubusercontent.com/42356429/86409345-1496e500-bc8f-11ea-879b-01e2c6e3dc98.gif)

DESK
![Fashionista copy](https://user-images.githubusercontent.com/42356429/86409354-195b9900-bc8f-11ea-96b4-68b449278cad.gif)


## Issue do repo


## Casos de Teste Pensados


## Descrição técnica da solução


## Dilemas, dúvidas e dívidas

