### PR TITLE
[RWLT-81-quebra-layout] 

### DIFF
--- a/src/components/Cart/Modal/style.scss
+++ b/src/components/Cart/Modal/style.scss
@@ -43,7 +43,12 @@
 
   &__list {
     overflow-y: scroll;
-    height: 65vh;
+    height: 66vh;
+
+    @media (max-width: $xs) {
+      height: 61vh;
+    }
+
     @media (min-width: $md) {
       height: 74vh;
     }
@@ -105,12 +110,4 @@
     color: $primary-light;
   }
 
-  &__removeItemBtn {
-    font-size: 100%;
-    font-family: inherit;
-    border: 0;
-    padding: 0;
-    background-color: transparent;
-    color: $warning;
-  }
 }

--- a/src/components/Cart/ProductBox/style.scss
+++ b/src/components/Cart/ProductBox/style.scss
@@ -24,5 +24,6 @@
     padding: 0;
     background-color: transparent;
     color: $warning;
+    cursor: pointer;
   }
 }


### PR DESCRIPTION
# Correção de quebra do scroll no iphone SE

## Descrição do PR
Correção de quebra do scroll que estava ocorrendo no iphone SE, impedindo de visualizar o último item. Também foi feito um pequeno ajuste na altura em iphone 6 e adicao de cursor pointer no botao de remover produto. Tinha um css duplicado para o botão, eu removi ele.

## Capturas de Tela
IPHONE SE
![Fashionista-iphone-se](https://user-images.githubusercontent.com/42356429/86496591-8a18b900-bd54-11ea-94e1-24401731326e.gif)

IPHONE 6
![iphone-6](https://user-images.githubusercontent.com/42356429/86496595-8d13a980-bd54-11ea-9235-28f76bab6679.gif)
## Issue do repo

Issue XYZ

## Casos de Teste Pensados


## Descrição técnica da solução


## Dilemas, dúvidas e dívidas

